### PR TITLE
feat: add support for no-auth configuration handling

### DIFF
--- a/apps/velero-ui-api/src/app/modules/app-config/app-config.controller.ts
+++ b/apps/velero-ui-api/src/app/modules/app-config/app-config.controller.ts
@@ -8,11 +8,15 @@ import type {
 } from '@velero-ui/shared-types';
 import { ConfigService } from '@nestjs/config';
 import { Public } from '@velero-ui-api/shared/decorators/public.decorator';
+import { AuthService } from '@velero-ui-api/modules/auth/auth.service';
 
 @Public()
 @Controller('config')
 export class AppConfigController {
-  constructor(private readonly configService: ConfigService) {}
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly authService: AuthService,
+  ) {}
 
   @Get()
   public getAppConfig(): Observable<Partial<AppPublicConfig>> {
@@ -27,6 +31,7 @@ export class AppConfigController {
     const config = {
       baseUrl,
       grafanaUrl,
+      noAuthRequired: this.authService.noAuthRequired(),
       basicAuth: {
         enabled: basicAuthEnabled || LDAPAuthEnabled,
       },

--- a/apps/velero-ui-api/src/app/modules/app-config/app-config.module.ts
+++ b/apps/velero-ui-api/src/app/modules/app-config/app-config.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { AppConfigController } from './app-config.controller';
+import { AuthModule } from '@velero-ui-api/modules/auth/auth.module';
 
 @Module({
+  imports: [AuthModule],
   controllers: [AppConfigController],
   providers: [],
 })

--- a/apps/velero-ui-api/src/app/modules/auth/auth.service.ts
+++ b/apps/velero-ui-api/src/app/modules/auth/auth.service.ts
@@ -10,6 +10,16 @@ export class AuthService {
     private readonly jwtService: JwtService,
   ) {}
 
+  public noAuthRequired(): boolean {
+    return !this.configService.get<boolean>('basicAuth.enabled', {infer: true}) &&
+      !this.configService.get<boolean>('github.enabled', {infer: true}) &&
+      !this.configService.get<boolean>('gitlab.enabled', {infer: true}) &&
+      !this.configService.get<boolean>('google.enabled', {infer: true}) &&
+      !this.configService.get<boolean>('microsoft.enabled', {infer: true}) &&
+      !this.configService.get<boolean>('oauth.enabled', {infer: true}) &&
+      !this.configService.get<boolean>('ldap.enabled', {infer: true});
+  }
+
   public validateBasicUser(username: string, password: string): boolean {
     const {
       enabled,

--- a/apps/velero-ui-api/src/app/modules/k8s-custom-object/k8s-custom-object.module.ts
+++ b/apps/velero-ui-api/src/app/modules/k8s-custom-object/k8s-custom-object.module.ts
@@ -2,9 +2,11 @@ import { Global, Module } from '@nestjs/common';
 import { K8sCustomObjectService } from './k8s-custom-object.service';
 import { K8sCustomObjectGateway } from '@velero-ui-api/modules/k8s-custom-object/k8s-custom-object.gateway';
 import { K8sCustomObjectController } from '@velero-ui-api/modules/k8s-custom-object/k8s-custom-object.controller';
+import { AuthModule } from '@velero-ui-api/modules/auth/auth.module';
 
 @Global()
 @Module({
+  imports: [AuthModule],
   providers: [K8sCustomObjectService, K8sCustomObjectGateway],
   exports: [K8sCustomObjectService],
   controllers: [K8sCustomObjectController],

--- a/apps/velero-ui-api/src/app/modules/settings/settings.module.ts
+++ b/apps/velero-ui-api/src/app/modules/settings/settings.module.ts
@@ -3,9 +3,10 @@ import { SettingsController } from './settings.controller';
 import { SettingsService } from './settings.service';
 import { ServerStatusRequestModule } from '@velero-ui-api/modules/server-status-request/server-status-request.module';
 import { SettingsGateway } from '@velero-ui-api/modules/settings/settings.gateway';
+import { AuthModule } from '@velero-ui-api/modules/auth/auth.module';
 
 @Module({
-  imports: [ServerStatusRequestModule],
+  imports: [AuthModule, ServerStatusRequestModule],
   controllers: [SettingsController],
   providers: [SettingsService, SettingsGateway],
 })

--- a/apps/velero-ui-api/src/app/shared/guards/jwt-auth.guard.ts
+++ b/apps/velero-ui-api/src/app/shared/guards/jwt-auth.guard.ts
@@ -2,10 +2,14 @@ import { ExecutionContext, Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { Reflector } from '@nestjs/core';
 import { IS_PUBLIC_KEY } from '@velero-ui-api/shared/decorators/public.decorator';
+import { AuthService } from '@velero-ui-api/modules/auth/auth.service';
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard(['jwt']) {
-  constructor(private reflector: Reflector) {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly authService: AuthService,
+  ) {
     super();
   }
 
@@ -14,7 +18,7 @@ export class JwtAuthGuard extends AuthGuard(['jwt']) {
       context.getHandler(),
       context.getClass(),
     ]);
-    if (isPublic) {
+    if (isPublic || this.authService.noAuthRequired()) {
       return true;
     }
     return super.canActivate(context);

--- a/apps/velero-ui-api/src/app/shared/guards/ws-jwt-auth.guard.ts
+++ b/apps/velero-ui-api/src/app/shared/guards/ws-jwt-auth.guard.ts
@@ -3,17 +3,23 @@ import * as jwt from 'jsonwebtoken';
 import { Socket } from 'socket.io';
 import { ConfigService } from '@nestjs/config';
 import { AppLogger } from '@velero-ui-api/shared/modules/logger/logger.service';
+import { AuthService } from '@velero-ui-api/modules/auth/auth.service';
 
 @Injectable()
 export class WsJwtAuthGuard implements CanActivate {
   constructor(
     private readonly logger: AppLogger,
     private readonly configService: ConfigService,
+    private readonly authService: AuthService,
   ) {}
 
   canActivate(context: ExecutionContext): boolean {
     const client: Socket = context.switchToWs().getClient<Socket>();
     const token = client.handshake?.auth?.token;
+
+    if (this.authService.noAuthRequired()) {
+      return true;
+    }
 
     if (!token) {
       client._error('Authentication error: No token provided');

--- a/apps/velero-ui/src/layouts/default/components/Header.vue
+++ b/apps/velero-ui/src/layouts/default/components/Header.vue
@@ -62,7 +62,7 @@
             <FontAwesomeIcon :icon="faSun" class="!w-5 !h-5" />
             <FontAwesomeIcon :icon="faMoon" class="hidden !w-5 !h-5" />
           </button> -->
-          <div v-click-out="clickOutside" class="flex flex-col items-center">
+          <div v-click-out="clickOutside" v-if="!noAuthRequired" class="flex flex-col items-center">
             <div class="flex items-center ml-3">
               <button
                 id="user-menu-button-2"
@@ -137,7 +137,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import type { Router } from 'vue-router';
 import { useRouter } from 'vue-router';
 import { getUser } from '@velero-ui-app/utils/jwt.utils';
-import type { JwtPayload } from '@velero-ui/shared-types';
+import type { AppPublicConfig, JwtPayload } from '@velero-ui/shared-types';
 import { useAppStore } from '@velero-ui-app/stores/app.store';
 import { useI18n } from 'vue-i18n';
 import { getLanguages } from '@velero-ui/i18n';
@@ -145,6 +145,8 @@ import type { SocketIO } from '@velero-ui-app/plugins/socket.plugin';
 
 const { t, locale } = useI18n();
 const socket: SocketIO = inject('socketIo');
+
+const { noAuthRequired } = inject('config') as AppPublicConfig;
 
 const router: Router = useRouter();
 const appStore = useAppStore();

--- a/apps/velero-ui/src/utils/guard.utils.ts
+++ b/apps/velero-ui/src/utils/guard.utils.ts
@@ -5,37 +5,48 @@ import type {
 } from 'vue-router';
 import { Pages } from './constants.utils';
 import { hasExpired } from '@velero-ui-app/utils/jwt.utils';
+import { inject } from 'vue';
+import type { AppPublicConfig } from '@velero-ui/shared-types';
 
 const guard: NavigationGuardWithThis<string> = async (
   to: RouteLocationNormalized,
 ): Promise<RouteLocationRaw> => {
   const accessToken: string = localStorage.getItem('access_token');
+  const { noAuthRequired } = inject('config') as AppPublicConfig;
 
-  if (accessToken) {
-    if (hasExpired(accessToken)) {
-      localStorage.removeItem('access_token');
-
-      return {
-        name: Pages.LOGIN.name,
-        query: {
-          state: 'error',
-          reason: 'inactivity',
-        },
-      };
-    }
-
+  if (noAuthRequired) {
+    localStorage.removeItem('access_token');
     if (to.name === Pages.LOGIN.name) {
       return { name: Pages.HOME.name };
     }
   } else {
-    if (!to.path.startsWith(Pages.LOGIN.path)) {
-      return {
-        name: Pages.LOGIN.name,
-        query: {
-          state: 'error',
-          reason: 'unauthorized',
-        },
-      };
+
+    if (accessToken) {
+      if (hasExpired(accessToken)) {
+        localStorage.removeItem('access_token');
+
+        return {
+          name: Pages.LOGIN.name,
+          query: {
+            state: 'error',
+            reason: 'inactivity',
+          },
+        };
+      }
+
+      if (to.name === Pages.LOGIN.name) {
+        return { name: Pages.HOME.name };
+      }
+    } else {
+      if (!to.path.startsWith(Pages.LOGIN.path)) {
+        return {
+          name: Pages.LOGIN.name,
+          query: {
+            state: 'error',
+            reason: 'unauthorized',
+          },
+        };
+      }
     }
   }
 };

--- a/apps/velero-ui/src/utils/jwt.utils.ts
+++ b/apps/velero-ui/src/utils/jwt.utils.ts
@@ -1,8 +1,9 @@
 import { jwtDecode } from 'jwt-decode';
+import type { JwtPayload } from '@velero-ui/shared-types';
 
 export const hasExpired = (token: string): boolean =>
   token ? Date.now() >= jwtDecode(token).exp * 1000 : false;
 
-export const getUser = (token: string) =>
+export const getUser = (token: string): JwtPayload =>
   token ? jwtDecode(token) : null;
 

--- a/libs/shared-types/src/models/config/config.models.ts
+++ b/libs/shared-types/src/models/config/config.models.ts
@@ -4,6 +4,7 @@ export enum Environment {
 }
 
 export interface AppPublicConfig extends AppConfig {
+  noAuthRequired: boolean;
   basicAuth: Partial<BasicAuthConfig>;
   google: Partial<GoogleConfig>;
   github: Partial<GithubConfig>;


### PR DESCRIPTION
Introduced a `noAuthRequired` flag to enable no-auth environments across the Velero UI and API. Adjusted guards, services, and components to respect this configuration, ensuring proper redirection and UI behavior when authentication is not required.