### PR TITLE
Change names role and role binding for namespace

### DIFF
--- a/kubernetes/chart/templates/roles.yml
+++ b/kubernetes/chart/templates/roles.yml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "velero-ui.fullname" . }}
+  name: {{ include "velero-ui.fullname" . }}-permissions
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "velero-ui.labels" . | nindent 4 }}
@@ -21,7 +21,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "velero-ui.fullname" . }}
+  name: {{ include "velero-ui.fullname" . }}-velero-permissions
   namespace: {{ .Values.configuration.general.veleroNamespace }}
   labels:
     {{- include "velero-ui.labels" . | nindent 4 }}

--- a/kubernetes/chart/templates/rolesbinding.yml
+++ b/kubernetes/chart/templates/rolesbinding.yml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "velero-ui.fullname" . }}
+  name: {{ include "velero-ui.fullname" . }}-permissions
   namespace: {{ .Release.Namespace }}
   labels:
       {{- include "velero-ui.labels" . | nindent 4 }}
@@ -19,7 +19,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "velero-ui.fullname" . }}
+  name: {{ include "velero-ui.fullname" . }}-velero-permissions
   namespace: {{ .Values.configuration.general.veleroNamespace }}
 subjects:
   - kind: ServiceAccount


### PR DESCRIPTION
If you currently deploy velero-ui and velero to the same namespace you have an issue with two the same names. This change will fix it.