### PR TITLE
fix: missing interval delay in setInterval functions

### DIFF
--- a/apps/velero-ui/src/components/Backup/BackupLine.vue
+++ b/apps/velero-ui/src/components/Backup/BackupLine.vue
@@ -281,7 +281,10 @@ const { download, downloadLoading } = useBackupDownloadContent(
 
 const interval = setInterval(
   () =>
-    (expireTime.value = getRemainingTime(props.data?.status?.expiration || '0'))
+    (expireTime.value = getRemainingTime(
+      props.data?.status?.expiration || '0'
+    )),
+  1000
 );
 
 onUnmounted(() => clearInterval(interval));

--- a/apps/velero-ui/src/components/Request/DownloadRequestLine.vue
+++ b/apps/velero-ui/src/components/Request/DownloadRequestLine.vue
@@ -204,7 +204,7 @@ const interval = setInterval(
   () =>
     (remainingTime.value = getRemainingTime(
       props.data?.status?.expiration || '0',
-    )),
+    )), 1000,
 );
 
 onUnmounted(() => clearInterval(interval));


### PR DESCRIPTION
Added a 1000ms delay to setInterval calls in DownloadRequestLine.vue and BackupLine.vue to ensure correct timing behavior. This change prevents potential issues with interval execution and improves consistency across these components.