### PR TITLE
fix: auth flows redirection

### DIFF
--- a/apps/velero-ui/src/composables/auth/useAuth.ts
+++ b/apps/velero-ui/src/composables/auth/useAuth.ts
@@ -18,10 +18,12 @@ export const useAuth = () => {
         })
       ).data,
     onSuccess: async (data) => {
-      if (data) {
+      if (data.access_token) {
         localStorage.setItem('access_token', data.access_token);
         resetSocketIOConnection();
-        await router.push('/');
+        await router.push('/dashboard');
+      } else {
+        await router.push('/?state=error&reason=sso');
       }
     },
     onError: async (error) => {

--- a/apps/velero-ui/src/composables/auth/useFormAuth.ts
+++ b/apps/velero-ui/src/composables/auth/useFormAuth.ts
@@ -32,10 +32,12 @@ export const useFormAuth = () => {
         )
       ).data,
     onSuccess: async (data) => {
-      if (data) {
+      if (data.access_token) {
         localStorage.setItem('access_token', data.access_token);
         resetSocketIOConnection();
-        await router.push('/');
+        await router.push('/dashboard');
+      } else {
+        await router.push('/?state=error&reason=credentials');
       }
     },
     onError: async (error) => {


### PR DESCRIPTION
Redirect users to error states if access tokens are missing during authentication. Successful logins now redirect to '/dashboard' instead of '/'.