### PR TITLE
fix: WebSocket authorization with policy checks

### DIFF
--- a/apps/velero-ui-api/src/app/modules/settings/settings.gateway.ts
+++ b/apps/velero-ui-api/src/app/modules/settings/settings.gateway.ts
@@ -16,6 +16,7 @@ import {
   CaslAbilityFactory,
 } from '@velero-ui-api/shared/modules/casl/casl-ability.factory';
 import { Action, LogType } from '@velero-ui/shared-types';
+import { CheckPolicies } from '@velero-ui-api/shared/decorators/check-policies.decorator';
 
 @WebSocketGateway({ cors: true })
 export class SettingsGateway
@@ -40,22 +41,18 @@ export class SettingsGateway
   }
 
   @UseGuards(WsJwtAuthGuard)
+  @CheckPolicies((ability: AppAbility) => ability.can(Action.Manage, 'all'))
   @SubscribeMessage('settings:logs:on')
   public logsServerOn(
     @ConnectedSocket() client: Socket,
     @MessageBody('type') type: LogType,
     @MessageBody('name') name: string
   ): void {
-    const ability: AppAbility = this.caslAbilityFactory.createForUser(
-      client.data.user
-    );
-
-    if (ability.can(Action.Manage, 'all')) {
-      this.settingsService.openLogsStream(client, type, name);
-    }
+    this.settingsService.openLogsStream(client, type, name);
   }
 
   @UseGuards(WsJwtAuthGuard)
+  @CheckPolicies((ability: AppAbility) => ability.can(Action.Manage, 'all'))
   @SubscribeMessage('settings:logs:off')
   public logsServerOff(@ConnectedSocket() client: Socket): void {
     this.settingsService.closeLogsSteam(client);

--- a/apps/velero-ui-api/src/app/shared/guards/ws-jwt-auth.guard.ts
+++ b/apps/velero-ui-api/src/app/shared/guards/ws-jwt-auth.guard.ts
@@ -4,13 +4,28 @@ import { Socket } from 'socket.io';
 import { ConfigService } from '@nestjs/config';
 import { AppLogger } from '@velero-ui-api/shared/modules/logger/logger.service';
 import { AuthService } from '@velero-ui-api/modules/auth/auth.service';
+import {
+  CHECK_POLICIES_KEY,
+  PolicyHandler,
+} from '@velero-ui-api/shared/decorators/check-policies.decorator';
+import {
+  AppAbility,
+  CaslAbilityFactory,
+} from '@velero-ui-api/shared/modules/casl/casl-ability.factory';
+import { PluralsNames } from '@velero-ui/velero';
+import { SUBJECT_KEY } from '@velero-ui-api/shared/decorators/subject.decorator';
+import { Reflector } from '@nestjs/core';
+import { WsException } from '@nestjs/websockets';
+import { data } from "autoprefixer";
 
 @Injectable()
 export class WsJwtAuthGuard implements CanActivate {
   constructor(
+    private readonly reflector: Reflector,
     private readonly logger: AppLogger,
     private readonly configService: ConfigService,
     private readonly authService: AuthService,
+    private readonly caslAbilityFactory: CaslAbilityFactory
   ) {}
 
   canActivate(context: ExecutionContext): boolean {
@@ -25,7 +40,7 @@ export class WsJwtAuthGuard implements CanActivate {
       client._error('Authentication error: No token provided');
       this.logger.error(
         `Client Authentication error ${client.id}: No token provided`,
-        WsJwtAuthGuard.name,
+        WsJwtAuthGuard.name
       );
       return false;
     }
@@ -35,13 +50,52 @@ export class WsJwtAuthGuard implements CanActivate {
         ignoreExpiration: false,
       });
       client.data.user = decoded;
+
+      const ability: AppAbility = this.caslAbilityFactory.createForUser(
+        client.data.user
+      );
+
+      const subject: PluralsNames =
+        this.reflector.getAllAndOverride<PluralsNames>(SUBJECT_KEY, [
+          context.getHandler(),
+          context.getClass(),
+        ]);
+
+      const policyHandlers: PolicyHandler[] =
+        this.reflector.get<PolicyHandler[]>(
+          CHECK_POLICIES_KEY,
+          context.getHandler()
+        ) || [];
+
+      const allAllowed: boolean = policyHandlers.every((handler) =>
+        this.execPolicyHandler(handler, ability, subject)
+      );
+
+      if (!allAllowed) {
+        throw new WsException('Access denied by policy');
+      }
+
       return true;
     } catch (error) {
-      client._error('Authentication error: Invalid token');
+      client._error(`Authentication error: ${error.message}`);
       this.logger.error(
-        `Client Authentication error ${client.id}: Invalid token`,
-        WsJwtAuthGuard.name,
+        `Client Authentication error ${client.id}: ${error.message}`,
+        WsJwtAuthGuard.name
       );
     }
+  }
+
+  private execPolicyHandler(
+    handler: PolicyHandler,
+    ability: AppAbility,
+    subject?: PluralsNames
+  ) {
+    if (typeof handler === 'function') {
+      if (handler.length === 2) {
+        return handler(ability, subject);
+      }
+      return handler(ability);
+    }
+    return handler.handle(ability);
   }
 }


### PR DESCRIPTION
Integrated policy-based access control in WsJwtAuthGuard and SettingsGateway. Added CASL-based ability checks and `@CheckPolicies` decorator to enforce granular permissions for WebSocket operations.