### PR TITLE
Fix Scheduled Backups on Dashboard when CRON_TZ is used in cron schedule

### DIFF
--- a/apps/velero-ui-api/src/app/modules/stats/stats.service.ts
+++ b/apps/velero-ui-api/src/app/modules/stats/stats.service.ts
@@ -240,7 +240,7 @@ export class StatsService {
           return scheduleList.items
             .map((schedule: V1Schedule) => {
               const scheduleStr = schedule.spec.schedule.trim();
-              const match = scheduleStr.match(/^(?:CRON_TZ|TZ)=([\w/+-]+)\s+(.*)$/);
+              const match = scheduleStr.match(/^(?:CRON_TZ)=([\w/+-]+)\s+(.*)$/);
 
               const { tz, cronSchedule } = match
                 ? { tz: match[1], cronSchedule: match[2] }


### PR DESCRIPTION
Currently if a schedule specifies a CRON_TZ in the cron string, the cron-parser library used by StatsService fails to parse the cron string.

This change extracts the CRON_TZ string if it exists and passes it through the CronExpressionParser's options.