### PR TITLE
fix: update volumeSnapshotLocations options to use dataSnapshotLocations

### DIFF
--- a/apps/velero-ui/src/components/Backup/forms/BackupFormInfo.vue
+++ b/apps/velero-ui/src/components/Backup/forms/BackupFormInfo.vue
@@ -127,7 +127,7 @@
           <FormKit
             :disabled="!dataSnapshotLocations || errorSnapshotLocations"
             :label="t('resource.spec.volumeSnapshotLocations')"
-            :options="dataStorageLocations?.items"
+            :options="dataSnapshotLocations?.items"
             multiple
             name="volumeSnapshotLocations"
             outer-class="mb-2"


### PR DESCRIPTION
update volumeSnapshotLocations options to use dataSnapshotLocations 
in the backup task creation page popup currently it shows datastorage location instead of dataSnapshotLocations 

<img width="396" height="275" alt="image" src="https://github.com/user-attachments/assets/14b58fa3-02df-4a81-bd44-c8e6720bd028" />
