### PR TITLE
Improve GitLab api `/group` functionality for bigger scenarios

### DIFF
--- a/apps/velero-ui-api/src/app/modules/auth/strategies/gitlab.strategy.ts
+++ b/apps/velero-ui-api/src/app/modules/auth/strategies/gitlab.strategy.ts
@@ -57,9 +57,9 @@ export class GitlabStrategy extends PassportStrategy(Strategy, 'gitlab') {
       );
 
       for (const group of groupsWithRoles) {
-        groups.push(group.name);
+        groups.push(group.fullPath);
         if (group.accessLevel !== 'unknown') {
-          groups.push(`${ group.name }:${ group.accessLevel }`);
+          groups.push(`${ group.fullPath }:${ group.accessLevel }`);
         }
       }
     }

--- a/apps/velero-ui-api/src/app/modules/auth/strategies/gitlab.strategy.ts
+++ b/apps/velero-ui-api/src/app/modules/auth/strategies/gitlab.strategy.ts
@@ -28,6 +28,7 @@ export class GitlabStrategy extends PassportStrategy(Strategy, 'gitlab') {
       scope: configService.get('gitlab.scopes'),
       callbackURL: configService.get('gitlab.redirectUri'),
       baseURL: configService.get('gitlab.baseUrl'),
+      searchTerm: configService.get('gitlab.searchTerm'),
     });
   }
 
@@ -55,7 +56,7 @@ export class GitlabStrategy extends PassportStrategy(Strategy, 'gitlab') {
       const groupsWithRoles = await lastValueFrom(
         this.getUserGroupsWithRoles(accessToken)
       );
-
+      
       for (const group of groupsWithRoles) {
         groups.push(group.fullPath);
         if (group.accessLevel !== 'unknown') {
@@ -83,8 +84,12 @@ export class GitlabStrategy extends PassportStrategy(Strategy, 'gitlab') {
   }
 
   private getUserGroupsWithRoles(accessToken: string) {
+    const url = new URL('/api/v4/groups', this.configService.get('gitlab.baseUrl'))
+
+    if (this.configService.get('gitlab.searchTerm')) url.searchParams.append('search', this.configService.get('gitlab.searchTerm'));
+
     return this.httpService
-      .get('https://gitlab.com/api/v4/groups', {
+      .get(url.toString(), {
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },

--- a/apps/velero-ui-api/src/app/modules/auth/strategies/gitlab.strategy.ts
+++ b/apps/velero-ui-api/src/app/modules/auth/strategies/gitlab.strategy.ts
@@ -5,7 +5,7 @@ import { Strategy } from 'passport-gitlab2';
 import { AppLogger } from '@velero-ui-api/shared/modules/logger/logger.service';
 import { AuthenticationException } from '@velero-ui-api/shared/exceptions/authentication.exception';
 import { HttpService } from '@nestjs/axios';
-import { catchError, lastValueFrom, map, of } from 'rxjs';
+import { catchError, lastValueFrom, of, mergeMap, expand, EMPTY, toArray } from 'rxjs';
 
 const GITLAB_ACCESS_LEVELS: Record<number, string> = {
   10: 'guest',
@@ -84,28 +84,49 @@ export class GitlabStrategy extends PassportStrategy(Strategy, 'gitlab') {
   }
 
   private getUserGroupsWithRoles(accessToken: string) {
-    const url = new URL('/api/v4/groups', this.configService.get('gitlab.baseUrl'))
+    const baseUrl = this.configService.get('gitlab.baseUrl');
+    const searchTerm = this.configService.get('gitlab.searchTerm');
 
-    if (this.configService.get('gitlab.searchTerm')) url.searchParams.append('search', this.configService.get('gitlab.searchTerm'));
+    const createUrl = (page: number) => {
+      const url = new URL('/api/v4/groups', baseUrl);
+      url.searchParams.append('page', page.toString());
+      url.searchParams.append('per_page', '100');
+      if (searchTerm) url.searchParams.append('search', searchTerm);
+      return url.toString();
+    };
 
     return this.httpService
-      .get(url.toString(), {
+      .get(createUrl(1), {
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },
       })
       .pipe(
-        map((res) =>
+        expand((response) => {
+          const currentPage = parseInt(response.headers['x-page'] || '1');
+          const totalPages = parseInt(response.headers['x-total-pages'] || '1');
+
+          if (currentPage < totalPages) {
+            return this.httpService.get(createUrl(currentPage + 1), {
+              headers: {
+                Authorization: `Bearer ${accessToken}`,
+              },
+            });
+          }
+          return EMPTY;
+        }),
+        mergeMap((res) =>
           res.data.map((group) => ({
             id: group.id,
             name: group.name,
             fullPath: group.full_path,
             accessLevel:
               GITLAB_ACCESS_LEVELS[
-                group.permissions?.group_access?.access_level
+              group.permissions?.group_access?.access_level
               ] || 'unknown',
           }))
         ),
+        toArray(),
         catchError((err) => {
           console.warn(
             'GitLab API error: ' + err.response?.data || err.message,

--- a/apps/velero-ui-api/src/app/modules/auth/strategies/gitlab.strategy.ts
+++ b/apps/velero-ui-api/src/app/modules/auth/strategies/gitlab.strategy.ts
@@ -56,7 +56,7 @@ export class GitlabStrategy extends PassportStrategy(Strategy, 'gitlab') {
       const groupsWithRoles = await lastValueFrom(
         this.getUserGroupsWithRoles(accessToken)
       );
-      
+
       for (const group of groupsWithRoles) {
         groups.push(group.fullPath);
         if (group.accessLevel !== 'unknown') {
@@ -67,6 +67,11 @@ export class GitlabStrategy extends PassportStrategy(Strategy, 'gitlab') {
 
     this.logger.info(
       `Federated Gitlab user ${id} signed in.`,
+      GitlabStrategy.name
+    );
+
+    this.logger.debug(
+      `User ${id} belongs to groups: ${groups.join(', ')}`,
       GitlabStrategy.name
     );
 
@@ -92,6 +97,12 @@ export class GitlabStrategy extends PassportStrategy(Strategy, 'gitlab') {
       url.searchParams.append('page', page.toString());
       url.searchParams.append('per_page', '100');
       if (searchTerm) url.searchParams.append('search', searchTerm);
+
+      this.logger.debug(
+        `Url created: ${url.toString()}`,
+        GitlabStrategy.name
+      );
+
       return url.toString();
     };
 

--- a/apps/velero-ui-api/src/config/gitlab.config.ts
+++ b/apps/velero-ui-api/src/config/gitlab.config.ts
@@ -10,5 +10,6 @@ export default registerAs('gitlab', (): GitlabConfig => {
     scopes: process.env.GITLAB_OAUTH_SCOPE || 'read_user',
     redirectUri: process.env.GITLAB_REDIRECT_URI || '',
     baseUrl: process.env.GITLAB_BASE_URL || 'https://gitlab.com/',
+    searchTerm: process.env.GITLAB_GROUP_SEARCH_TERM || '',
   };
 });

--- a/docs/docs/sso-ldap/providers/gitlab.md
+++ b/docs/docs/sso-ldap/providers/gitlab.md
@@ -19,6 +19,7 @@ To enable GitLab authentication, set the following environment variables:
 | `GITLAB_OAUTH_SCOPE` | The scope of OAuth access. Default: `read_user`. |
 | `GITLAB_REDIRECT_URI` | The redirect URI after authentication. Default: `http://localhost:4200/login`. |
 | `GITLAB_BASE_URL` | The base URL of your GitLab instance (use `https://gitlab.com` for the official GitLab service). |
+| `GITLAB_GROUP_SEARCH_TERM` | The search term used to filter groups returned when checking for group membership. Nice to have if you have a lot of groups. Default is ``. |
 
 ## Steps to Configure GitLab Authentication
 
@@ -39,6 +40,7 @@ To enable GitLab authentication, set the following environment variables:
      GITLAB_OAUTH_SCOPE="read_user" # read_api
      GITLAB_REDIRECT_URI=http://localhost:4200/login
      GITLAB_BASE_URL=https://gitlab.com
+     GITLAB_GROUP_SEARCH_TERM="subgroup-x" # optional
      ```
 
 3. **Restart Your Application**
@@ -50,7 +52,7 @@ If you are using GitLab Groups for RBAC, ensure that the `read_api` scope is inc
 
 Group members can be granted access to Velero UI based on their GitLab group memberships.
 
-**Group syntax is** `group_name:role_in_group`, example: `my-group:owner`, `my-group:maintainer`, `my-group:guest`.
+**Group syntax is** `full/path/group_name:role_in_group`, example: `it-department/my-group:owner`, `it-department/my-group:maintainer`, `it-department/my-group:guest`.
 
 Gitlab roles:
 - `owner`
@@ -69,6 +71,7 @@ Then refer to the [RBAC documentation](../rbac.md) for further configuration.
 - Inspect logs for authentication errors.
 - Verify that your GitLab OAuth credentials are correct.
 - If using a self-hosted GitLab instance, set `GITLAB_BASE_URL` accordingly.
+- Check that it works without setting the `GITLAB_GROUP_SEARCH_TERM`. This should return all groups when checking against policies.
 
 ## Conclusion
 

--- a/libs/shared-types/src/models/config/config.models.ts
+++ b/libs/shared-types/src/models/config/config.models.ts
@@ -76,6 +76,7 @@ export interface GitlabConfig {
   scopes: string;
   redirectUri: string;
   baseUrl: string;
+  searchTerm?: string;
 }
 
 export interface OauthConfig {


### PR DESCRIPTION
**The issues I am facing**

Today, if you are using velero-ui with gitlab oidc login, there are three issues:

1. If running self-hosted gitlab instance, you will not be able to use the RBAC-functionality, because the gitlab auth-strategy uses a hard-coded url to `https://gitlab.com/api/v4/groups`, while the oauth flow uses something like this: `$baseUrl/path`.
2. The auth logic only uses the name of the group for policy matching. The name in gitlab groups is not unique. This can be solved by using fullpath instead.
3. The query used to list groups you have access to returns at most 100 results. This means that if you have 101 groups and you want to have add a role for users in group 101 (in alphabetical order), this will fail, as this group is never returned.

**Proposed solution**

For the different issues, I propose the given solutions:

1. The url for the gitlab-api should use the same base-url. As far as I know, gitlab does not differentiate the base url for either cloud or self-hosted instances.
2. After the groups are fetched from the API, the `fullpath` is added to the groups-list used for policy matching instead of the initial `name`-property. WARNING! This could be a breaking change for users that have already implemented only with the group names.
3. Implement both search-term added as a env-variable and pagination to retreive all the results. 

**As mentioned in proposed solution 2: This will bring on a potential breaking change**