### PR TITLE
fixed "false" value, checking value with  != null

### DIFF
--- a/apps/velero-ui/src/components/Backup/forms/BackupFormRestore.vue
+++ b/apps/velero-ui/src/components/Backup/forms/BackupFormRestore.vue
@@ -111,7 +111,7 @@ const onSubmit = () => {
     form.spec.excludedNamespaces = formContent.value[1].excludedNamespaces;
   }
 
-  if (formContent.value[1].writeSparseFiles) {
+  if (formContent.value[1].writeSparseFiles != null) {
     form.spec.uploaderConfig.writeSparseFiles =
       formContent.value[1].writeSparseFiles;
   }
@@ -121,15 +121,15 @@ const onSubmit = () => {
       parseInt(formContent.value[1].parallelFilesDownload);
   }
 
-  if (formContent.value[1].preserveNodePorts) {
+  if (formContent.value[1].preserveNodePorts != null) {
     form.spec.preserveNodePorts = formContent.value[1].preserveNodePorts;
   }
 
-  if (formContent.value[1].restorePVs) {
+  if (formContent.value[1].restorePVs != null) {
     form.spec.restorePVs = formContent.value[1].restorePVs;
   }
 
-  if (formContent.value[1].includeClusterResources) {
+  if (formContent.value[1].includeClusterResources != null) {
     form.spec.includeClusterResources =
       formContent.value[1].includeClusterResources;
   }

--- a/apps/velero-ui/src/components/Restore/forms/RestoreFormCreate.vue
+++ b/apps/velero-ui/src/components/Restore/forms/RestoreFormCreate.vue
@@ -91,7 +91,7 @@ const onSubmit = () => {
     form.spec.scheduleName = formContent.value[1].scheduleName;
   }
 
-  if (formContent.value[2].writeSparseFiles) {
+  if (formContent.value[2].writeSparseFiles != null) {
     form.spec.uploaderConfig.writeSparseFiles =
       formContent.value[2].writeSparseFiles;
   }
@@ -101,15 +101,15 @@ const onSubmit = () => {
       parseInt(formContent.value[2].parallelFilesDownload);
   }
 
-  if (formContent.value[2].preserveNodePorts) {
+  if (formContent.value[2].preserveNodePorts != null) {
     form.spec.preserveNodePorts = formContent.value[2].preserveNodePorts;
   }
 
-  if (formContent.value[2].restorePVs) {
+  if (formContent.value[2].restorePVs != null) {
     form.spec.restorePVs = formContent.value[2].restorePVs;
   }
 
-  if (formContent.value[2].includeClusterResources) {
+  if (formContent.value[2].includeClusterResources != null) {
     form.spec.includeClusterResources =
       formContent.value[2].includeClusterResources;
   }


### PR DESCRIPTION
This PR fixes a UI bug where boolean restore options could not be saved correctly when set to `false`.

The restore forms were using truthy checks before writing values into the generated Restore spec. Because of that, if a user explicitly selected `false` for options such as `writeSparseFiles`, `preserveNodePorts`, `restorePVs`, or `includeClusterResources`, the field was omitted instead of being sent as `false`.

The fix replaces those truthy checks with `!= null` checks in both restore form components, so explicit `false` values are now preserved, while `null` and `undefined` are still omitted as intended.