### PR TITLE
fix(api): enforce authorization on routes missing @CheckPolicies

### DIFF
--- a/apps/velero-ui-api/src/app/modules/backup/backup.controller.ts
+++ b/apps/velero-ui-api/src/app/modules/backup/backup.controller.ts
@@ -43,6 +43,9 @@ export class BackupController extends K8sCustomObjectController<V1Backup> {
   }
 
   @Post('/download')
+  @CheckPolicies((ability: AppAbility) =>
+    ability.can(Action.Read, Resources.BACKUP.plural)
+  )
   public download(@Body() names: string[]) {
     return forkJoin(
       names.map((name) =>

--- a/apps/velero-ui-api/src/app/modules/form/form.controller.ts
+++ b/apps/velero-ui-api/src/app/modules/form/form.controller.ts
@@ -1,43 +1,67 @@
 import { Controller, Get } from '@nestjs/common';
 import { FormService } from '@velero-ui-api/modules/form/form.service';
 import { Observable } from 'rxjs';
-import { FormList } from '@velero-ui/shared-types';
+import { Action, FormList } from '@velero-ui/shared-types';
+import { CheckPolicies } from '@velero-ui-api/shared/decorators/check-policies.decorator';
+import { AppAbility } from '@velero-ui-api/shared/modules/casl/casl-ability.factory';
+import { Resources } from '@velero-ui/velero';
 
 @Controller('form')
 export class FormController {
   constructor(private readonly formService: FormService) {}
 
   @Get('/schedules')
+  @CheckPolicies((ability: AppAbility) =>
+    ability.can(Action.Read, Resources.SCHEDULE.plural)
+  )
   public getFormSchedules(): Observable<FormList<string>> {
     return this.formService.getSchedules();
   }
 
   @Get('/backups')
+  @CheckPolicies((ability: AppAbility) =>
+    ability.can(Action.Read, Resources.BACKUP.plural)
+  )
   public getFormBackups(): Observable<FormList<string>> {
     return this.formService.getBackups();
   }
 
   @Get('/namespaces')
+  @CheckPolicies((ability: AppAbility) =>
+    ability.can(Action.Read, Resources.BACKUP.plural)
+  )
   public getNamespaces(): Observable<FormList<string>> {
     return this.formService.getNamespaces();
   }
 
   @Get('/storage-locations')
+  @CheckPolicies((ability: AppAbility) =>
+    ability.can(Action.Read, Resources.BACKUP_STORAGE_LOCATION.plural)
+  )
   public getStorageLocations(): Observable<FormList<string>> {
     return this.formService.getStorageLocations();
   }
 
   @Get('/snapshot-locations')
+  @CheckPolicies((ability: AppAbility) =>
+    ability.can(Action.Read, Resources.VOLUME_SNAPSHOT_LOCATION.plural)
+  )
   public getSnapshotLocations(): Observable<FormList<string>> {
     return this.formService.getSnapshotLocations();
   }
 
   @Get('/secrets')
+  @CheckPolicies((ability: AppAbility) =>
+    ability.can(Action.Read, Resources.BACKUP_STORAGE_LOCATION.plural)
+  )
   public getFormSecrets(): Observable<FormList<string>> {
     return this.formService.getSecrets();
   }
 
   @Get('/config-maps')
+  @CheckPolicies((ability: AppAbility) =>
+    ability.can(Action.Read, Resources.BACKUP_STORAGE_LOCATION.plural)
+  )
   public getFormConfigMaps(): Observable<FormList<string>> {
     return this.formService.getConfigMaps();
   }

--- a/apps/velero-ui-api/src/app/modules/k8s-custom-object/k8s-custom-object.gateway.ts
+++ b/apps/velero-ui-api/src/app/modules/k8s-custom-object/k8s-custom-object.gateway.ts
@@ -10,7 +10,7 @@ import { UseGuards } from '@nestjs/common';
 import { WsJwtAuthGuard } from '@velero-ui-api/shared/guards/ws-jwt-auth.guard';
 import { K8sCustomObjectService } from '@velero-ui-api/modules/k8s-custom-object/k8s-custom-object.service';
 import { AppAbility, CaslAbilityFactory } from '@velero-ui-api/shared/modules/casl/casl-ability.factory';
-import { Resources } from "@velero-ui/velero";
+import { PluralsNames } from "@velero-ui/velero";
 import { Action } from "@velero-ui/shared-types";
 
 @WebSocketGateway({ cors: true })
@@ -32,16 +32,16 @@ export class K8sCustomObjectGateway implements OnGatewayDisconnect {
     @MessageBody('plural') plural: string,
     @MessageBody('version') version: string
   ): void {
-    const ability: AppAbility = this.caslAbilityFactory.createForUser(client.data.user);
+    const ability: AppAbility = this.caslAbilityFactory.createForUser(
+      client.data.user
+    );
 
-    for (const [key, value] of Object.entries(Resources)) {
-      if (ability.can(Action.Read, value.plural)) {
-        this.k8sCustomObjectService.watch(client, plural, name, version);
-        break;
-      }
+    // Authorize on the REQUESTED resource (plural), not "can read anything".
+    if (!ability.can(Action.Read, plural as PluralsNames)) {
+      throw new WsException('Access denied by policy');
     }
 
-    throw new WsException('Access denied by policy');
+    this.k8sCustomObjectService.watch(client, plural, name, version);
   }
 
   @UseGuards(WsJwtAuthGuard)

--- a/apps/velero-ui-api/src/app/modules/settings/settings.controller.ts
+++ b/apps/velero-ui-api/src/app/modules/settings/settings.controller.ts
@@ -25,6 +25,7 @@ export class SettingsController {
   }
 
   @Get('/velero/server')
+  @CheckPolicies((ability: AppAbility) => ability.can(Action.Manage, 'all'))
   public getVeleroServer(): Observable<VeleroServerSettings> {
     return this.settingsService.getVeleroServer();
   }
@@ -35,6 +36,8 @@ export class SettingsController {
     return this.settingsService.getVeleroAgents();
   }
 
+  // Intentionally readable by any authenticated user: returns only the velero-ui
+  // app version/mode, needed by the SPA to bootstrap. No @CheckPolicies on purpose.
   @Get('/velero/ui')
   public getVeleroUi(): Observable<VeleroUiSettings> {
     return this.settingsService.getVeleroUi();
@@ -54,6 +57,7 @@ export class SettingsController {
   }
 
   @Delete('/velero/plugins/:name')
+  @CheckPolicies((ability: AppAbility) => ability.can(Action.Manage, 'all'))
   public deleteVeleroPluginByName(@Param('name') name: string) {
     return {};
   }

--- a/apps/velero-ui-api/src/app/modules/stats/stats.controller.ts
+++ b/apps/velero-ui-api/src/app/modules/stats/stats.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, UseInterceptors } from '@nestjs/common';
 import { StatsService } from '@velero-ui-api/modules/stats/stats.service';
 import { Observable } from 'rxjs';
 import {
+  Action,
   BackupsNextScheduled,
   BackupsStatusStats,
   BackupsSuccessRateStats,
@@ -9,49 +10,78 @@ import {
   RestoresStatusStats,
   RestoresSuccessRateStats,
 } from '@velero-ui/shared-types';
-import { CacheInterceptor } from "@nestjs/cache-manager";
+import { CacheInterceptor } from '@nestjs/cache-manager';
+import { CheckPolicies } from '@velero-ui-api/shared/decorators/check-policies.decorator';
+import { Subject } from '@velero-ui-api/shared/decorators/subject.decorator';
+import { AppAbility } from '@velero-ui-api/shared/modules/casl/casl-ability.factory';
+import { PluralsNames, Resources } from '@velero-ui/velero';
 
 @Controller('stats')
+@Subject(Resources.BACKUP.plural)
 @UseInterceptors(CacheInterceptor)
 export class StatsController {
   constructor(private readonly statsService: StatsService) {}
 
   @Get()
+  @CheckPolicies((ability: AppAbility, resource: PluralsNames) =>
+    ability.can(Action.Read, resource)
+  )
   public getBasicStats(): Observable<BasicStats> {
     return this.statsService.getBasicStats();
   }
 
   @Get('/backups/status')
+  @CheckPolicies((ability: AppAbility, resource: PluralsNames) =>
+    ability.can(Action.Read, resource)
+  )
   public getBackupsStatus(): Observable<BackupsStatusStats> {
     return this.statsService.getBackupsStatus();
   }
 
   @Get('/backups/success-rate')
+  @CheckPolicies((ability: AppAbility, resource: PluralsNames) =>
+    ability.can(Action.Read, resource)
+  )
   public getBackupsSuccessRate(): Observable<BackupsSuccessRateStats> {
     return this.statsService.getBackupsSuccessRate();
   }
 
   @Get('/restores/status')
+  @CheckPolicies((ability: AppAbility) =>
+    ability.can(Action.Read, Resources.RESTORE.plural)
+  )
   public getRestoresStatus(): Observable<RestoresStatusStats> {
     return this.statsService.getRestoresStatus();
   }
 
   @Get('/restores/success-rate')
+  @CheckPolicies((ability: AppAbility) =>
+    ability.can(Action.Read, Resources.RESTORE.plural)
+  )
   public getRestoresSuccessRate(): Observable<RestoresSuccessRateStats> {
     return this.statsService.getRestoresSuccessRate();
   }
 
   @Get('/backups/next-scheduled')
+  @CheckPolicies((ability: AppAbility, resource: PluralsNames) =>
+    ability.can(Action.Read, resource)
+  )
   public getNextScheduledBackups(): Observable<BackupsNextScheduled[]> {
     return this.statsService.getNextScheduledBackups();
   }
 
   @Get('/backups/latest')
+  @CheckPolicies((ability: AppAbility, resource: PluralsNames) =>
+    ability.can(Action.Read, resource)
+  )
   public getBackupLatest() {
     return this.statsService.getBackupLatest();
   }
 
   @Get('/unscheduled-namespaces')
+  @CheckPolicies((ability: AppAbility, resource: PluralsNames) =>
+    ability.can(Action.Read, resource)
+  )
   public getUnscheduledNamespaces(): Observable<string[]> {
     return this.statsService.getUnscheduledNamespaces();
   }


### PR DESCRIPTION
## Problem

`JwtAuthGuard` is registered as a global `APP_GUARD` and performs both authentication
and CASL policy enforcement. The policy part reads the check-policies metadata at the
**method level only**:

```ts
const policyHandlers =
  this.reflector.get<PolicyHandler[]>(CHECK_POLICIES_KEY, context.getHandler()) || [];
const allAllowed = policyHandlers.every((h) => this.execPolicyHandler(h, ability, subject));
```

When a route has no method-level `@CheckPolicies`, `policyHandlers` is `[]` and
`[].every(...) === true` → **access is granted to any authenticated user**. A
class-level `@CheckPolicies` does not help (it is read with `getHandler()`, not
`getAllAndOverride`), so every route must carry its own decorator.

On a deployment backed by a shared OIDC realm (multiple tenants, one realm), this means
a user authenticated on the realm but with no matching policy can reach these routes.

## Affected routes

| Controller | Route | Exposure |
| --- | --- | --- |
| `StatsController` | all `/stats/*` | aggregated stats + namespace names |
| `BackupController` | `POST /backups/download` | downloads backup **contents** |
| `FormController` | the 7 `GET /form/*` | namespaces / secrets / config-maps names, cluster-wide |
| `SettingsController` | `GET /settings/velero/server`, `DELETE /settings/velero/plugins/:name` | server info; plugin deletion |
| `K8sCustomObjectGateway` | `watch:on` (WS) | see below |

`GET /settings/velero/ui` is intentionally left open to any authenticated user (it only
returns the app version/mode needed to bootstrap the UI) — documented with a comment.

## Fix

- Add a method-level `@CheckPolicies` to every previously-unprotected route, using the
  action/subject consistent with the rest of each controller:
  - `POST /backups/download` → `Read` on backups.
  - `GET /form/*` → `Read` on the matching resource (schedules, backups, namespaces →
    backups; storage-locations / secrets / config-maps → backup storage locations;
    snapshot-locations → volume snapshot locations).
  - `GET /settings/velero/server` and `DELETE /settings/velero/plugins/:name` →
    `Manage all`, matching `/settings/cluster`, `/settings/velero/agents` and the other
    plugin routes.
- Fix the `watch:on` gateway authorization. It previously checked whether the user could
  read **any** resource and then watched the **requested** one, and it threw
  `WsException` unconditionally after the loop (even on success):

  ```ts
  for (const [key, value] of Object.entries(Resources)) {
    if (ability.can(Action.Read, value.plural)) {
      this.k8sCustomObjectService.watch(client, plural, name, version);
      break;
    }
  }
  throw new WsException('Access denied by policy');
  ```

  It now authorizes the **requested** `plural` and only throws when denied:

  ```ts
  if (!ability.can(Action.Read, plural as PluralsNames)) {
    throw new WsException('Access denied by policy');
  }
  this.k8sCustomObjectService.watch(client, plural, name, version);
  ```

## Notes

No behavior change for users who already hold the relevant abilities; only previously
implicit access for users without any matching policy is now denied.
